### PR TITLE
cfam: Use targeting libs to do cfam access in ecmd-pdbg

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'ecmd-pdbg',
     ['cpp','c'],
     default_options: [
-        'cpp_std=c++17',
+        'cpp_std=c++20',
         'default_library=shared',
     ],
     meson_version : '>= 0.51',

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,6 +22,11 @@ if get_option('journal').enabled()
     libsystemd_pkg = dependency('libsystemd')
 endif
 
+dep_targeting = dependency('libtargeting', required: true)
+dep_hwaccess = dependency('libhwaccess', required: true)
+dep_targetsvc = dependency('libtargetsvc', required: true)
+dep_transport = dependency('libtransport', required: true)
+
 libedbg = library(
             'edbg',
             'common/edbgCommon.C',
@@ -47,7 +52,9 @@ libedbg = library(
             '../ecmd/ecmd-core/dll/ecmdDllCapi.C',
             '../' + autogen_path + '/cipDllCapi.C',
             include_directories : headers,
-            dependencies : [libcpp,libfs, libyaml, libpdbg, libipl, libekb, get_option('journal').enabled() ? libsystemd_pkg :[]],
+            dependencies : [libcpp,libfs, libyaml, libpdbg, libipl, libekb,
+                            dep_targeting, dep_hwaccess, dep_targetsvc, dep_transport,
+                            get_option('journal').enabled() ? libsystemd_pkg :[]],
             link_with : libecmd,
             version: meson.project_version(),
             install: true)


### PR DESCRIPTION
Verified:
root@p11bmc:~# putcfam pu 2808 00004000 -p0
HwBaseAccess::putCfam executed
getFSIBasePath Found FSI base path: /sys/class/fsi-master/
putcfam for addr=0x2808 value=0x400000
pu	k0:n0:s0:p00
/usr/bin/edbg putcfam pu 2808 00004000 -p0

root@p11bmc:~# getcfam pu 2801 -pall
HwBaseAccess::getCfam executed
getFSIBasePath Found FSI base path: /sys/class/fsi-master/
getcfam for addr=0x2801 value=0x84c00002
pu	k0:n0:s0:p00       0x84C00002